### PR TITLE
Add PQL and Node Group support to Invoke-PuppetTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.7]
+### Changed
+- `Invoke-PuppetTask` can now target `nodes`, `query`, or `node_group`. This parameters on `Invoke-PuppetTask` have been changed and are not backwards compatible with version 0.1.6 and below.
 
 ## [0.1.6]
 ### Added
@@ -11,29 +15,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.1.5]
 ### Added
- - added pester tests
- - token nodes in readme
- - be consistent with how we write out object with > item
+- added pester tests
+- token nodes in readme
+- be consistent with how we write out object with > item
 
 ## [0.1.4]
 ### Added
- - bump build reqs
- - changed md docs location
- - added function docs
- - updated readme
+- bump build reqs
+- changed md docs location
+- added function docs
+- updated readme
 
 ## [0.1.3]
 ### Added
- - Adding more docs.
+- Adding more docs.
 
 ## [0.1.2]
 ### Added
- - Adding more docs.
+- Adding more docs.
 
 ## [0.1.1]
 ### Added
- - Adding docs.
+- Adding docs.
 
 ## [0.1.0]
 ### Added
- - Initial release.
+- Initial release.

--- a/PSPuppetOrchestrator/PSPuppetOrchestrator.psd1
+++ b/PSPuppetOrchestrator/PSPuppetOrchestrator.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSPuppetOrchestrator.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.6'
+ModuleVersion = '0.1.7'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -27,7 +27,7 @@ Author = 'Joey Piccola'
 CompanyName = 'Community'
 
 # Copyright statement for this module
-Copyright = '(c) 2019 Joey Piccola. All rights reserved.'
+Copyright = '(c) 2020 Joey Piccola. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'PowerShell module for calling the Puppet Orchestrator API.'

--- a/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
+++ b/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
@@ -13,12 +13,15 @@ Function Invoke-PuppetTask {
     .PARAMETER Description
         A description to submit along with the task.
     .PARAMETER Nodes
-        An array of nodes the Puppet task will be invoked against, e.g. $Scope = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3').
+        An array of node names to target, e.g. $Scope = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3').
     .PARAMETER Query
-        A PuppetDB query the Puppet task will be invoked against, e.g. '["from", "inventory", ["=", "facts.os.name", "windows"]]'.
+        A PuppetDB or PQL query to use to discover nodes. The target is built from the certname values collected at
+        the top level of the query, e.g. '["from", "inventory", ["=", "facts.os.name", "windows"]]'.
     .PARAMETER Node_group
-        A GUID of a node group the Puppet task will be invoked against, e.g. 7a692b61-8087-4452-9cf8-58ed2acee2a0.
-        Can be found in a URL of the WebUI when on a selected node group.
+        A classifier node group ID. The ID must correspond to a node group that has defined rules. It is not sufficient
+        for parent groups of the node group in question to define rules. The user must also have permissions to view the
+        node group. Any nodes specified in the scope that the user does not have permissions to run the task on are
+        excluded, e.g. 7a692b61-8087-4452-9cf8-58ed2acee2a0.
     .PARAMETER WaitLoopInterval
         An optional time in seconds that the wait feature will re-check the invoked task. DEFAULTS to 5s.
     .PARAMETER Wait

--- a/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
+++ b/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
@@ -12,20 +12,19 @@ Function Invoke-PuppetTask {
         A hash of parameters to supply the Puppet task, e.g. $Parameters = @{tp1 = 'foo';tp2 = 'bar'; tp3 = $true}.
     .PARAMETER Description
         A description to submit along with the task.
-    .PARAMETER Scope
+    .PARAMETER Nodes
         An array of nodes the Puppet task will be invoked against, e.g. $Scope = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3').
-    .PARAMETER ScopeType
-        When executing tasks against the /command/task API endpoint you can either use
-        a scope type of 'node' or 'query'. At this time, PSPuppetOrchestrator only
-        supports a ScopeType of 'node' which is the DEFAULT and only allowed option for
-        the ScopeType parameter.
+    .PARAMETER Query
+        A PuppetDB query the Puppet task will be invoked against, e.g. '["from", "inventory", ["=", "facts.os.name", "windows"]]'.
+    .PARAMETER Node_group
+        A GUID of a node group the Puppet task will be invoked against, e.g. 7a692b61-8087-4452-9cf8-58ed2acee2a0.
+        Can be found in a URL of the WebUI when on a selected node group.
+    .PARAMETER WaitLoopInterval
+        An optional time in seconds that the wait feature will re-check the invoked task. DEFAULTS to 5s.
     .PARAMETER Wait
         An optional wait value in seconds that Invoke-PuppetTask will use to wait until
         the invoked task completes. If the wait time is exceeded Invoke-PuppetTask will
         return a warning.
-    .PARAMETER WaitLoopInterval
-        An optional time in seconds that the wait feature will re-check the invoked task.
-        DEFAULTS to 5s.
     .PARAMETER Token
         The Puppet API orchestrator token.
     .PARAMETER Master
@@ -38,14 +37,43 @@ Function Invoke-PuppetTask {
             Environment      = 'production'
             Parameters       = @{action = 'set'; reboot = $true}
             Description      = 'Disable smbv1 on 08r2 nodes.'
-            Scope            = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3')
-            ScopeType        = 'nodes'
-            Wait             = 120
-            WaitLoopInterval = 2
+            Nodes            = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3')
         }
         PS> Invoke-PuppetTask @invokePuppetTaskSplat
 
-        job info
+        id                                                       name
+        --                                                       ----
+        https://puppet.contoso.us:8143/orchestrator/v1/jobs/1318 1318
+    .EXAMPLE
+        $invokePuppetTaskSplat = @{
+            Token            = $token
+            Master           = $master
+            Task             = 'powershell_tasks::disablesmbv1'
+            Environment      = 'production'
+            Parameters       = @{action = 'set'; reboot = $true}
+            Description      = 'Disable smbv1 on 08r2 nodes.'
+            Query            = '["from", "inventory", ["=", "facts.os.name", "windows"]]'
+        }
+        PS> Invoke-PuppetTask @invokePuppetTaskSplat
+
+        id                                                       name
+        --                                                       ----
+        https://puppet.contoso.us:8143/orchestrator/v1/jobs/1318 1318
+    .EXAMPLE
+        $invokePuppetTaskSplat = @{
+            Token            = $token
+            Master           = $master
+            Task             = 'powershell_tasks::disablesmbv1'
+            Environment      = 'production'
+            Parameters       = @{action = 'set'; reboot = $true}
+            Description      = 'Disable smbv1 on 08r2 nodes.'
+            Node_group       = '7a692b61-8087-4452-9cf8-58ed2acee2a0'
+        }
+        PS> Invoke-PuppetTask @invokePuppetTaskSplat
+
+        id                                                       name
+        --                                                       ----
+        https://puppet.contoso.us:8143/orchestrator/v1/jobs/1318 1318
     #>
 
     Param(
@@ -61,16 +89,26 @@ Function Invoke-PuppetTask {
         [hashtable]$Parameters = @{},
         [Parameter()]
         [string]$Description = '',
-        [Parameter(Mandatory)]
-        [string[]]$Scope,
-        [Parameter()]
-        [ValidateSet('nodes')]
-        [string]$ScopeType = 'nodes',
         [Parameter()]
         [int]$Wait,
         [Parameter()]
-        [int]$WaitLoopInterval = 5
+        [int]$WaitLoopInterval = 5,
+        [Parameter(Mandatory, ParameterSetName = "nodes")]
+        [string[]]$Nodes,
+        [Parameter(Mandatory, ParameterSetName = "query")]
+        [string]$Query,
+        [Parameter(Mandatory, ParameterSetName = "node_group")]
+        [string]$Node_group
     )
+
+    # set the scope type to the name of the oh so cleverly named parameter set
+    $scopeType = $PSCmdlet.ParameterSetName
+    # set the scope to the value of the single parameter of the choosen parameter set
+    switch ($scopeType) {
+        'nodes'      {$scope = $Nodes}
+        'query'      {$scope = $Query}
+        'node_group' {$scope = $Node_group}
+    }
 
     $req = [PSCustomObject]@{
         environment = $Environment
@@ -78,10 +116,10 @@ Function Invoke-PuppetTask {
         params      = $Parameters
         description = $Description
         scope       = [PSCustomObject]@{
-            $ScopeType  = $Scope
+            $scopeType  = $scope
         }
     } | ConvertTo-Json
-    $req
+
     $hoststr = "https://$master`:8143/orchestrator/v1/command/task"
     $headers = @{'X-Authentication' = $Token}
 

--- a/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
+++ b/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
@@ -44,6 +44,8 @@ Function Invoke-PuppetTask {
             WaitLoopInterval = 2
         }
         PS> Invoke-PuppetTask @invokePuppetTaskSplat
+
+        job info
     #>
 
     Param(

--- a/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
+++ b/PSPuppetOrchestrator/Public/Invoke-PuppetTask.ps1
@@ -124,16 +124,15 @@ Function Invoke-PuppetTask {
     $headers = @{'X-Authentication' = $Token}
 
     $result  = Invoke-RestMethod -Uri $hoststr -Method Post -Headers $headers -Body $req
-    $content = $result
 
-    if ($wait) {
+    if ($PSBoundParameters.ContainsKey('wait')) {
         # sleep 5s for the job to register
         Start-Sleep -Seconds 5
 
         $jobSplat = @{
             token  = $Token
             master = $master
-            id     = $content.job.name
+            id     = $result.job.name
         }
 
         # create a timespan
@@ -157,6 +156,6 @@ Function Invoke-PuppetTask {
             break
         }
     } else {
-        Write-Output $content.job
+        Write-Output $result.job
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PS> Install-Module -Name PSPuppetOrchestrator
 ```
 
 ## Included Functions
+
 `Invoke-PuppetTask`
 
 `Get-PuppetTask`
@@ -28,38 +29,45 @@ PS> Install-Module -Name PSPuppetOrchestrator
 `Get-PuppetPCPNodeBrokerDetails`
 
 ## Token
-In order to call the `orchestrator` API endpoint you'll need a user token. There are a couple methods to acquire a Puppet Enterprise user token. In the spirit of using PowerShell, below is a script to get a token via the `rbac-api` endpoint. Specify a numeric value followed by “y” (years), “d” (days), “h” (hours), “m” (minutes), or “s”(seconds) for `lifeimte`. If you do not want the token to expire, set the lifetime to “0”. Setting it to zero gives the token a lifetime of approximately 10 years. Do consider correctly filling out 'description', 'client', and 'label' with accurate information (they're all optional and can be removed if needed). 'description', 'client', and 'label' help with token audits.
+
+In order to call the `orchestrator` API endpoint you'll need a user token. There are a couple methods to acquire a Puppet Enterprise user token. In the spirit of using PowerShell, below is a script to get a token via the `rbac-api` endpoint. Specify a numeric value followed by “y” (years), “d” (days), “h” (hours), “m” (minutes), or “s”(seconds) for `lifetime`. If you do not want the token to expire, set the lifetime to “0”. Setting it to zero gives the token a lifetime of approximately 10 years. Do consider correctly filling out 'description', 'client', and 'label' with accurate information (they're all optional and can be removed if needed). 'description', 'client', and 'label' help with token audits.
 
 ```powershell
-$puppetMaster = 'puppet.contoso.com'
+$master = 'puppet.contoso.com'
 $cred = Get-Credential -Message 'Puppet Credentials (e.g. myuser-p)'
 $req = [PSCustomObject]@{
-    login    = $cred.UserName
-    password = $cred.GetNetworkCredential().Password
-    lifetime = '1d'
+    login       = $cred.UserName
+    password    = $cred.GetNetworkCredential().Password
+    lifetime    = '1d'
     description = "Token used for testing puppet tasks"
-    client = ""
-    label = "personal workstation token"
+    client      = ""
+    label       = "personal workstation token"
 } | ConvertTo-Json
-
-$hoststr = "https://$puppetMaster`:4433/rbac-api/v1/auth/token"
-$result  = Invoke-RestMethod -Uri $hoststr -Method Post -Body $req -ContentType 'application/json'
+$rbacUri = "https://$master`:4433/rbac-api/v1/auth/token"
+$result  = Invoke-RestMethod -Uri $rbacUri -Method Post -Body $req -ContentType 'application/json'
 $result
 ```
+
 OUTPUT
-```
+
+```plaintext
 token
 -----
 ***********************************wCB8
 ```
 
 ## Examples
+
 ### Get tasks
+
 Get a list of tasks.
+
 ```powershell
 PS> Get-PuppetTasks -token $token -master $master
 ```
+
 OUTPUT
+
 ```plaintext
 id                                                                       name                            permitted
 --                                                                       ----                            ---------
@@ -71,190 +79,199 @@ https://puppet:8143/orchestrator/v1/tasks/powershell_tasks/disablesmbv1  powersh
 ```
 
 ### Run tasks
-Create a parameter splat.
+
+`Invoke-PuppetTask` can target nodes three different ways by specifying **one** of the following parameters.
+
+- Nodes
+  - EXAMPLE: `-Nodes @('node1.contoso.com','node2.contoso.com','node3.contoso.com','node4.contoso.com')`
+- Query
+  - EXAMPLE: `-Query '["from", "inventory", ["=", "facts.os.name", "windows"]]'`
+- Node_group
+  - EXAMPLE: `-Node_group '7a692b61-8087-4452-9cf8-58ed2acee2a0'`
+
+#### Invoke-PuppetTask Parameter Splat Examples
+
+Create an `Invoke-PuppetTask` parameter splat to target and array of nodes.
+
 ```powershell
 $invokePuppetTaskSplat = @{
-    Token       = $token
-    Master      = $master
-    Task        = 'powershell_tasks::disablesmbv1'
-    Environment = 'production'
-    Parameters  = @{action = 'set'; reboot = $true}
-    Description = 'Disable smbv1 on 08r2 nodes.'
-    Scope       = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3')
+    Token  = $token
+    Master = $master
+    Task   = 'jpi::get_dns'
+    Nodes  = @('node1.contoso.com','node2.contoso.com','node3.contoso.com','node4.contoso.com')
 }
 ```
-Invoke the task `powershell_tasks::disablesmbv1`.
+
+Create an `Invoke-PuppetTask` parameter splat to target nodes from a PQL query.
+
 ```powershell
-PS> Invoke-PuppetTask @invokePuppetTaskSplat
-```
-OUTPUT
-```plaintext
-id                                           name
---                                           ----
-https://puppet:8143/orchestrator/v1/jobs/910 910
+$invokePuppetTaskSplat = @{
+    Token  = $token
+    Master = $master
+    Task   = 'jpi::get_dns'
+    Query  = '["from", "inventory", ["=", "facts.os.name", "windows"]]'
+}
 ```
 
-Invoke the task `powershell_tasks::disablesmbv1` and `-Wait` a max of 120 seconds for the job to complete before returning. Note, the job will continue to run even if we exceed our `-Wait` time of 120 seconds.
+Create an `Invoke-PuppetTask` parameter splat to target a node group.
+
 ```powershell
-PS> Invoke-PuppetTask @invokePuppetTaskSplat -Wait 120
+$invokePuppetTaskSplat = @{
+    Token      = $token
+    Master     = $master
+    Task       = 'jpi::get_dns'
+    Node_group = '7a692b61-8087-4452-9cf8-58ed2acee2a0'
+}
 ```
+
+Create an `Invoke-PuppetTask` parameter splat specifying additional parameters for the `jpi::set_dns` Puppet Task.
+
+```powershell
+$invokePuppetTaskSplat = @{
+    Token            = $token
+    Master           = $master
+    Task             = 'jpi::set_dns'
+    Parameters       = @{
+        primary   = '10.0.3.24'
+        secondary = '10.0.3.22'
+        tertiary  = '8.8.8.8'
+    }
+    Nodes            = @('node1.contoso.com', 'node2.contoso.com')
+}
+```
+
+Create an `Invoke-PuppetTask` parameter splat specifying additional parameters for the `jpi::set_dns` Puppet Task and `-Wait` 120 seconds for the job to complete. **Note, the job will continue to run even if the job exceeds the `-Wait` time of 120 seconds.**
+
+```powershell
+$invokePuppetTaskSplat = @{
+    Token            = $token
+    Master           = $master
+    Task             = 'jpi::set_dns'
+    Parameters       = @{
+        primary   = '10.0.3.24'
+        secondary = '10.0.3.22'
+        tertiary  = '8.8.8.8'
+    }
+    Nodes            = @('node1.contoso.com', 'node2.contoso.com')
+    Wait             = 120
+}
+```
+
+#### Invoke-PuppetTask Outputs
+
+When `Invoke-PuppetTask` is supplied the `-Wait` parameter and the job completes within the wait time you'll be returned the full job results (identical to the results given by `Get-PuppetJob`).
+
 OUTPUT
-```
-description : Disable smbv1 on 08r2 nodes.
-report      : @{id=https://puppet:8143/orchestrator/v1/jobs/940/report}
-name        : 940
-events      : @{id=https://puppet:8143/orchestrator/v1/jobs/940/events}
+
+```plaintext
+description :
+report      : @{id=https://puppet.contoso.us:8143/orchestrator/v1/jobs/1326/report}
+name        : 1326
+events      : @{id=https://puppet.contoso.us:8143/orchestrator/v1/jobs/1326/events}
 command     : task
 type        : task
 state       : finished
-nodes       : @{id=https://puppet:8143/orchestrator/v1/jobs/940/nodes}
-status      : {@{state=ready; enter_time=10/4/19 6:17:50 PM; exit_time=10/4/19 6:17:50 PM}, @{state=running; enter_time=10/4/19 6:17:50 PM; exit_time=10/4/19 6:17:52 PM}, @{state=finished; enter_time=10/4/19
-              6:17:52 PM; exit_time=}}
-id          : https://puppet:8143/orchestrator/v1/jobs/940
+nodes       : @{id=https://puppet.contoso.us:8143/orchestrator/v1/jobs/1326/nodes}
+status      : {@{state=ready; enter_time=4/8/2020 6:22:21 PM; exit_time=4/8/2020 6:22:21 PM}, @{state=running; enter_time=4/8/2020 6:22:21 PM; exit_time=4/8/2020 6:22:24 PM}, @{state=finished; enter_time=4/8/2020 6:22:24 PM; exit_time=}}
+id          : https://puppet.contoso.us:8143/orchestrator/v1/jobs/1326
 environment : @{name=production}
-options     : @{description=Disable smbv1 on 08r2 nodes.; transport=pxp; noop=False; task=powershell_tasks::disablesmbv1; sensitive=System.Object[]; scheduled-job-id=; params=; scope=; environment=production}
-timestamp   : 10/4/19 6:17:52 PM
-owner       : @{email=; is_revoked=False; last_login=10/4/19 5:52:55 PM; is_remote=False; login=admin; is_superuser=True; id=42bf351c-f9ec-40af-84ad-e976fec7f4bd; role_ids=System.Object[];
-              display_name=Administrator; is_group=False}
-node_count  : 3
-node_states : @{finished=3}
+options     : @{description=; transport=pxp; noop=False; task=jpi::set_dns; sensitive=System.Object[]; scheduled-job-id=; params=; scope=; environment=production}
+timestamp   : 4/8/2020 6:22:24 PM
+owner       : @{email=; is_revoked=False; last_login=4/8/2020 6:17:18 PM; is_remote=False; login=admin; is_superuser=True; id=42bf351c-f9ec-40af-84ad-e976fec7f4bd; role_ids=System.Object[]; display_name=Administrator; is_group=False}
+node_count  : 1
+node_states : @{finished=1}
+```
+
+When `Invoke-PuppetTask` is not supplied the `-Wait` parameter you'll immediately be returned the `id` and `name` of the job.
+
+OUTPUT
+
+```plaintext
+
+id                                                       name
+--                                                       ----
+https://puppet.piccola.us:8143/orchestrator/v1/jobs/1324 1324
 ```
 
 ### Get task report
-Using the `name` value of `940` returned from previously executed `Invoke-PuppetTask` get the report.
+
+Using the `name` value of `1324` returned from previously executed `Invoke-PuppetTask` get the report.
+
 ```powershell
-PS> Get-PuppetJobReport -Master $master -Token $token -ID 940
+PS> Get-PuppetJobReport -Master $master -Token $token -ID 1324
 ```
+
 OUTPUT
+
 ```plaintext
-node             : den3w108r2psv3
+node             : node1.contoso.com
 state            : finished
-start_timestamp  : 2019-09-09T16:54:07Z
-finish_timestamp : 2019-09-09T16:54:09Z
-timestamp        : 2019-09-09T16:54:09Z
-events           : {}
-
-node             : den3w112r2psv4
-state            : finished
-start_timestamp  : 2019-09-09T16:54:07Z
-finish_timestamp : 2019-09-09T16:54:13Z
-timestamp        : 2019-09-09T16:54:13Z
-events           : {}
-
-node             : den3w112r2psv5
-state            : finished
-start_timestamp  : 2019-09-09T16:54:07Z
-finish_timestamp : 2019-09-09T16:54:13Z
-timestamp        : 2019-09-09T16:54:13Z
+start_timestamp  : 4/8/2020 4:45:06 PM
+finish_timestamp : 4/8/2020 4:45:08 PM
+timestamp        : 4/8/2020 4:45:08 PM
 events           : {}
 ```
 
 ### Get tasks results
-Using the `name` returned from `Invoke-PuppetTask` get the results. In this example there is no output result.
+
+Using the `name` returned from `Invoke-PuppetTask` get the results. Depending on the depth of the structured data returned from the task you may have to "dot explore" into it.
+
 ```powershell
-PS> Get-PuppetJobResults -Master $master -Token $token -ID 940
+PS> Get-PuppetJobResults -Master $master -Token $token -ID 1324 -OutVariable 'PuppetJobResults'
 ```
+
 OUTPUT
+
 ```plaintext
-finish_timestamp : 2019-09-09T16:54:09Z
-transaction_uuid :
-start_timestamp  : 2019-09-09T16:54:07Z
-name             : den3w108r2psv3
-duration         : 2.032
-state            : finished
-details          :
-result           : @{_output=}
-latest-event-id  : 5581
-timestamp        : 2019-09-09T16:54:09Z
-
-finish_timestamp : 2019-09-09T16:54:13Z
-transaction_uuid :
-start_timestamp  : 2019-09-09T16:54:07Z
-name             : den3w112r2psv4
-duration         : 5.071
-state            : finished
-details          :
-result           : @{_output=}
-latest-event-id  : 5582
-timestamp        : 2019-09-09T16:54:13Z
-
-finish_timestamp : 2019-09-09T16:54:13Z
-transaction_uuid :
-start_timestamp  : 2019-09-09T16:54:07Z
-name             : den3w112r2psv5
-duration         : 5.071
-state            : finished
-details          :
-result           : @{_output=}
-latest-event-id  : 5582
-timestamp        : 2019-09-09T16:54:13Z
+PS> $PuppetJobResults
+    transport        : pcp
+    finish_timestamp : 4/8/2020 4:45:08 PM
+    transaction_uuid :
+    start_timestamp  : 4/8/2020 4:45:06 PM
+    name             : node1.contoso.com
+    duration         : 2.275
+    state            : finished
+    details          :
+    result           : @{after=; before=}
+    latest-event-id  : 9510
+    timestamp        : 4/8/2020 4:45:08 PM
 ```
-### Get task results continued
-The following output is from the `powershell_tasks::getkb` that generates output.
-```powershell
-PS> Get-PuppetJobResults -Master $master -Token $token -ID 915 -OutVariable 'PuppetJobResults'
-```
-OUTPUT
-```plaintext
-finish_timestamp : 2019-09-09T17:16:03Z
-transaction_uuid :
-start_timestamp  : 2019-09-09T17:15:48Z
-name             : den3w108r2psv3
-duration         : 15.645
-state            : finished
-details          :
-result           : @{Source=DEN3W108R2PSV3; HotFixID=KB2620704; Description=Security Update; InstalledBy=; InstalledOn=Friday, September 07, 2018 12:00:00 AM}
-latest-event-id  : 5596
-timestamp        : 2019-09-09T17:16:03Z
 
-finish_timestamp : 2019-09-09T17:16:04Z
-transaction_uuid :
-start_timestamp  : 2019-09-09T17:15:48Z
-name             : den3w108r2psv4
-duration         : 15.989
-state            : finished
-details          :
-result           : @{Source=DEN3W108R2PSV4; HotFixID=KB2620704; Description=Security Update; InstalledBy=; InstalledOn=Friday, September 07, 2018 12:00:00 AM}
-latest-event-id  : 5597
-timestamp        : 2019-09-09T17:16:04Z
+Though very specific to the `jpi::set_dns` Puppet Task, below is the extended result data returned from job `1324`. Retrieved with `$PuppetJobResults.result | ConvertTo-Json`.
 
-finish_timestamp : 2019-09-09T17:16:09Z
-transaction_uuid :
-start_timestamp  : 2019-09-09T17:15:48Z
-name             : den3w108r2psv5
-duration         : 21.802
-state            : finished
-details          :
-result           : @{Source=DEN3W108R2PSV5; HotFixID=KB2620704; Description=Security Update; InstalledBy=NT AUTHORITY\SYSTEM; InstalledOn=Thursday, September 06, 2018 12:00:00 AM}
-latest-event-id  : 5598
-timestamp        : 2019-09-09T17:16:09Z
-```
-Using `-OutVariable 'PuppetJobResults'` from before we can access the `results` for each node the task was run against.
-```powershell
-PS C:\> $PuppetJobResults.result
-```
-OUTPUT
-```plaintext
-Source      : DEN3W108R2PSV3
-HotFixID    : KB2620704
-Description : Security Update
-InstalledBy :
-InstalledOn : Friday, September 07, 2018 12:00:00 AM
-
-Source      : DEN3W108R2PSV4
-HotFixID    : KB2620704
-Description : Security Update
-InstalledBy :
-InstalledOn : Friday, September 07, 2018 12:00:00 AM
-
-Source      : DEN3W108R2PSV5
-HotFixID    : KB2620704
-Description : Security Update
-InstalledBy : NT AUTHORITY\SYSTEM
-InstalledOn : Thursday, September 06, 2018 12:00:00 AM
+```json
+{
+  "after": {
+    "Index": 4,
+    "IPAddress": [
+      "10.0.3.117",
+      "fe80::987b:9b0a:1532:8d2d"
+    ],
+    "MACAddress": "00:50:56:89:53:29",
+    "DNSServerSearchOrder": [
+      "10.0.3.24",
+      "10.0.3.22",
+      "8.8.8.8"
+    ]
+  },
+  "before": {
+    "Index": 4,
+    "IPAddress": [
+      "10.0.3.117",
+      "fe80::987b:9b0a:1532:8d2d"
+    ],
+    "MACAddress": "00:50:56:89:53:29",
+    "DNSServerSearchOrder": [
+      "10.0.3.24",
+      "10.0.3.22",
+      "8.8.8.8"
+    ]
+  }
+}
 ```
 
 ## License
+
 PSPuppetOrchestrator is released under the [MIT license](http://www.opensource.org/licenses/MIT).
 
 [appveyor]: https://ci.appveyor.com/project/joeypiccola/pspuppetorchestrator

--- a/Tests/Help.tests.ps1
+++ b/Tests/Help.tests.ps1
@@ -12,7 +12,7 @@ $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVers
 #Get-Module $env:BHProjectName | Remove-Module -Force
 #Import-Module -Name (Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1") -Verbose:$false -ErrorAction Stop
 Import-Module $outputModDir
-$commands = Get-Command -Module (Get-Module $env:BHProjectName) -CommandType Cmdlet, Function, Workflow  # Not alias
+$commands = Get-Command -Module (Get-Module $env:BHProjectName) -CommandType Cmdlet, Function  # Not alias
 
 ## When testing help, remember that help is cached at the beginning of each session.
 ## To test, restart session.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 0.1.6.{build}
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PowerShellEdition: PowerShellCore
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PowerShellEdition: WindowsPowerShell

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 0.1.6.{build}
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PowerShellEdition: PowerShellCore
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PowerShellEdition: WindowsPowerShell

--- a/docs/en-US/Invoke-PuppetTask.md
+++ b/docs/en-US/Invoke-PuppetTask.md
@@ -12,10 +12,25 @@ Invoke a Puppet task.
 
 ## SYNTAX
 
+### nodes
 ```
-Invoke-PuppetTask [-Token] <String> [-Master] <String> [-Task] <String> [[-Environment] <String>]
- [[-Parameters] <Hashtable>] [[-Description] <String>] [-Scope] <String[]> [[-ScopeType] <String>]
- [[-Wait] <Int32>] [[-WaitLoopInterval] <Int32>] [<CommonParameters>]
+Invoke-PuppetTask -Token <String> -Master <String> -Task <String> [-Environment <String>]
+ [-Parameters <Hashtable>] [-Description <String>] [-Wait <Int32>] [-WaitLoopInterval <Int32>]
+ -Nodes <String[]> [<CommonParameters>]
+```
+
+### query
+```
+Invoke-PuppetTask -Token <String> -Master <String> -Task <String> [-Environment <String>]
+ [-Parameters <Hashtable>] [-Description <String>] [-Wait <Int32>] [-WaitLoopInterval <Int32>] -Query <String>
+ [<CommonParameters>]
+```
+
+### node_group
+```
+Invoke-PuppetTask -Token <String> -Master <String> -Task <String> [-Environment <String>]
+ [-Parameters <Hashtable>] [-Description <String>] [-Wait <Int32>] [-WaitLoopInterval <Int32>]
+ -Node_group <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,20 +41,56 @@ Invoke a Puppet task.
 ### EXAMPLE 1
 ```
 $invokePuppetTaskSplat = @{
-```
-
-Token            = $token
+    Token            = $token
     Master           = $master
     Task             = 'powershell_tasks::disablesmbv1'
     Environment      = 'production'
     Parameters       = @{action = 'set'; reboot = $true}
     Description      = 'Disable smbv1 on 08r2 nodes.'
-    Scope            = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3')
-    ScopeType        = 'nodes'
-    Wait             = 120
-    WaitLoopInterval = 2
+    Nodes            = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3')
 }
-PS\> Invoke-PuppetTask @invokePuppetTaskSplat
+PS> Invoke-PuppetTask @invokePuppetTaskSplat
+```
+
+id                                                       name
+--                                                       ----
+https://puppet.contoso.us:8143/orchestrator/v1/jobs/1318 1318
+
+### EXAMPLE 2
+```
+$invokePuppetTaskSplat = @{
+    Token            = $token
+    Master           = $master
+    Task             = 'powershell_tasks::disablesmbv1'
+    Environment      = 'production'
+    Parameters       = @{action = 'set'; reboot = $true}
+    Description      = 'Disable smbv1 on 08r2 nodes.'
+    Query            = '["from", "inventory", ["=", "facts.os.name", "windows"]]'
+}
+PS> Invoke-PuppetTask @invokePuppetTaskSplat
+```
+
+id                                                       name
+--                                                       ----
+https://puppet.contoso.us:8143/orchestrator/v1/jobs/1318 1318
+
+### EXAMPLE 3
+```
+$invokePuppetTaskSplat = @{
+    Token            = $token
+    Master           = $master
+    Task             = 'powershell_tasks::disablesmbv1'
+    Environment      = 'production'
+    Parameters       = @{action = 'set'; reboot = $true}
+    Description      = 'Disable smbv1 on 08r2 nodes.'
+    Node_group       = '7a692b61-8087-4452-9cf8-58ed2acee2a0'
+}
+PS> Invoke-PuppetTask @invokePuppetTaskSplat
+```
+
+id                                                       name
+--                                                       ----
+https://puppet.contoso.us:8143/orchestrator/v1/jobs/1318 1318
 
 ## PARAMETERS
 
@@ -52,7 +103,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -67,7 +118,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -82,7 +133,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -97,7 +148,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: Production
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -113,7 +164,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: @{}
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -128,43 +179,8 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Scope
-An array of nodes the Puppet task will be invoked against, e.g.
-$Scope = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3').
-
-```yaml
-Type: String[]
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 7
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ScopeType
-When executing tasks against the /command/task API endpoint you can either use
-a scope type of 'node' or 'query'.
-At this time, PSPuppetOrchestrator only
-supports a ScopeType of 'node' which is the DEFAULT and only allowed option for
-the ScopeType parameter.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 8
-Default value: Nodes
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -181,7 +197,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: Named
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -197,8 +213,65 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: Named
 Default value: 5
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Nodes
+An array of node names to target, e.g.
+$Scope = @('DEN3W108R2PSV5','DEN3W108R2PSV4','DEN3W108R2PSV3').
+
+```yaml
+Type: String[]
+Parameter Sets: nodes
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+A PuppetDB or PQL query to use to discover nodes.
+The target is built from the certname values collected at
+the top level of the query, e.g.
+'\["from", "inventory", \["=", "facts.os.name", "windows"\]\]'.
+
+```yaml
+Type: String
+Parameter Sets: query
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Node_group
+A classifier node group ID.
+The ID must correspond to a node group that has defined rules.
+It is not sufficient
+for parent groups of the node group in question to define rules.
+The user must also have permissions to view the
+node group.
+Any nodes specified in the scope that the user does not have permissions to run the task on are
+excluded, e.g.
+7a692b61-8087-4452-9cf8-58ed2acee2a0.
+
+```yaml
+Type: String
+Parameter Sets: node_group
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -3,7 +3,7 @@
         Target = 'CurrentUser'
     }
     'Pester' = @{
-        Version = '4.9.0'
+        Version = '4.10.1'
     }
     'psake' = @{
         Version = '4.9.0'


### PR DESCRIPTION
Refactor how scope types are handed in `Invoke-PuppetTask` allowing for `query` and `node_group`.