### PR TITLE
Add Get-PuppetAuthToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8]
+## Added
+- `Get-PuppetAuthToken` You can now provide a server name for your Puppet master and optionally a listening port, along with a credential, and easily obtain an api auth token for use with the rest of the cmdlets in the module.
+
 ## [0.1.7]
 ### Changed
 - `Invoke-PuppetTask` can now target `nodes`, `query`, or `node_group`. This parameters on `Invoke-PuppetTask` have been changed and are not backwards compatible with version 0.1.6 and below.

--- a/PSPuppetOrchestrator/PSPuppetOrchestrator.psd1
+++ b/PSPuppetOrchestrator/PSPuppetOrchestrator.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSPuppetOrchestrator.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.7'
+ModuleVersion = '0.1.8'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -120,5 +120,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-
-

--- a/PSPuppetOrchestrator/Private/Set-ServerCertificateValidationCallback.ps1
+++ b/PSPuppetOrchestrator/Private/Set-ServerCertificateValidationCallback.ps1
@@ -1,0 +1,18 @@
+function Set-ServerCertificateValidationCallback {
+    <#
+    .SYNOPSIS
+        A stub for testing purposes.
+    .DESCRIPTION
+        This cmdlet stubs the call to setting the callback to true so that it
+        can tested via pester and it's use can be detected via Assert-MockCalled
+
+    .EXAMPLE
+        Set-ServerCertificateValidationCallback
+
+        This is a stub method used internally to make Pester Testing easier. It sets
+        the ServerCertificateValidationCallback method in a way that's easier to
+        Mock during testing.
+    #>
+
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+}

--- a/PSPuppetOrchestrator/Private/Set-SkipCertificateCheck.ps1
+++ b/PSPuppetOrchestrator/Private/Set-SkipCertificateCheck.ps1
@@ -1,0 +1,60 @@
+function Set-SkipCertificateCheck {
+    <#
+    .SYNOPSIS
+        Detect Invoke-RestMethod version and ignore server ssl certs.
+
+    .DESCRIPTION
+        Detect whether certificate checking should be skipped via the switch
+        parameter on Invoke-RestMethod or via setting the ServerCertificateCallback
+        setting.
+
+    .PARAMETER SkipCertificateCheck
+        Indicate that you would like to skip SSL Certificate validation from
+        the Master server and trust the certificate you receive.
+
+    .PARAMETER PARAMS
+        The hash table of params you will eventually use with Invoke-RestMethod.
+        This cmdlet will add a SkipCertificateCheck key and set it to true if
+        the current version of Invoke-RestMethod supports that switch. If it
+        does not then it will set the ServerCertificateValidationCallback
+        method to always return true and achieve the same effect.
+
+    .EXAMPLE
+        $invokeParams = @{
+        >>         Uri                  = $uri
+        >>         Method               = 'Post'
+        >>         Body                 = $req
+        >>         ContentType          = 'application/json'
+        >>     }
+
+        PS > $invokeParams = Set-SkipCertificateCheck -SkipCertificateCheck $SkipCertificateCheck -Params $invokeParams
+
+        PS > Invoke-RestMethod @invokeParams | Select-Object -ExpandProperty token
+
+        This example detect if the current version of Invoke-RestMethod implements the -SkipCertificateCheck switch parameter
+        If it does then it will add that key to the $invokeParams hash table for use when splatting with Invoke-RestMethod.
+        If it does not then it will set the ServerCertificateValidationCallback method in .NET to always return $true
+        to acheive the same effect in PowerShell 5.1
+
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [bool]
+        $SkipCertificateCheck,
+        [Parameter(Mandatory)]
+        [hashtable]
+        $params
+    )
+
+    process {
+        if ($SkipCertificateCheck) {
+            if (Get-Help Invoke-RestMethod -Parameter SkipCertificateCheck -ErrorAction SilentlyContinue) {
+                $params.SkipCertificateCheck = $true
+            } else {
+                Set-ServerCertificateValidationCallback
+            }
+        }
+        $params
+    }
+}

--- a/PSPuppetOrchestrator/Public/Get-PuppetAuthToken.ps1
+++ b/PSPuppetOrchestrator/Public/Get-PuppetAuthToken.ps1
@@ -1,0 +1,100 @@
+function Get-PuppetAuthToken {
+    <#
+    .SYNOPSIS
+        Get a Puppet Auth Token for use with API calls.
+    .DESCRIPTION
+        Call the /rbac-api/v1/auth/token end point with a username and password
+        to obtain an authorization token that can be used with the other
+        cmdlets in this module.
+
+    .PARAMETER Master
+        The FQDN of the Puppet Master server that your DNS can resolve. You do
+        not need to include the HTTPS portion of the address. Only the server name.
+
+    .PARAMETER Lifetime
+        An integer value specifying how long you would like the token to last
+        paired with one of the letter [smhdy] (example '2d' for two days) to
+        specify the units of time in seconds, minutes, hours, days, or years. If
+        you call this cmdlet to request a token within the valid lifetime of
+        your current token, you will receive your current token back again.
+
+    .PARAMETER Port
+        The port your Puppet Master API end poins are listening on. Be default
+        this will be 4433, but it is configurable.
+
+    .PARAMETER Credential
+        A PSCredential object that contains the username and password for the user
+        you would like to receive a token for. If you do not provide one you will
+        be prompted at the commandline for one.
+
+    .PARAMETER SkipCertificateCheck
+        Skip certificate validation on the SSL certificate provided by the Puppet
+        master server you connect to. This parameter will function as expected
+        for both PowerShell 5.1 and 6+.
+
+    .EXAMPLE
+        $cred = Get-Credential -Username Admin
+        PS > $token = Get-PuppetAuthToken -Master 'pe-master.corp.net' -SkipCertificateCheck -Credential $cred
+
+        Create a credential object and then call this cmdlet to retrieve a token
+
+    .EXAMPLE
+        $token = Get-PuppetAuthToken -Master 'pe-master.corp.net' -SkipCertificateCheck
+
+        If you do not pass a credential object, you will be prompted for credentials.
+
+    .EXAMPLE
+        $token = Get-PuppetAuthToken -Lifetime '2m' -Master 'pe-master.corp.net' -SkipCertificateCheck
+
+        Create a short lived token so that an automated process can use it but it
+        dies quickley thereafter.
+    .INPUTS
+        Inputs (if any)
+    .OUTPUTS
+        [String] Authorization Token Value.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [String]$Master,
+        [Parameter()]
+        [String]
+        $Lifetime = '1d',
+        [Parameter()]
+        [Int]$Port = 4433,
+        [Parameter(Mandatory)]
+        [PSCredential]$Credential,
+        [Parameter()]
+        [Switch]$SkipCertificateCheck = $false
+    )
+    process {
+        $uri = "https://$Master`:$port/rbac-api/v1/auth/token"
+
+        $req = [PSCustomObject]@{
+            login       = $credential.UserName
+            password    = $credential.GetNetworkCredential().Password
+            lifetime    = $Lifetime
+            description = "Token used for authentication to Puppet api requests."
+            label       = "Personal Workstation token"
+        } | ConvertTo-JSON
+
+        $invokeParams = @{
+            Uri                  = $uri
+            Method               = 'Post'
+            Body                 = $req
+            ContentType          = 'application/json'
+        }
+
+        $invokeParams = Set-SkipCertificateCheck -SkipCertificateCheck $SkipCertificateCheck -Params $invokeParams
+
+        try {
+            Invoke-RestMethod @invokeParams | Select-Object -ExpandProperty token
+        }
+        catch {
+            Write-Error $_.Exception.Message
+        }
+        finally {
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $null
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,31 +28,23 @@ PS> Install-Module -Name PSPuppetOrchestrator
 
 `Get-PuppetPCPNodeBrokerDetails`
 
+`Get-PuppetAuthToken`
+
 ## Token
 
-In order to call the `orchestrator` API endpoint you'll need a user token. There are a couple methods to acquire a Puppet Enterprise user token. In the spirit of using PowerShell, below is a script to get a token via the `rbac-api` endpoint. Specify a numeric value followed by “y” (years), “d” (days), “h” (hours), “m” (minutes), or “s”(seconds) for `lifetime`. If you do not want the token to expire, set the lifetime to “0”. Setting it to zero gives the token a lifetime of approximately 10 years. Do consider correctly filling out 'description', 'client', and 'label' with accurate information (they're all optional and can be removed if needed). 'description', 'client', and 'label' help with token audits.
+In order to call the `orchestrator` API endpoint you'll need a user token. You can call the `Get-PuppetAuthToken` cmdlet to acquire a token. You can use the `-SkipCertificateCheck` switch in case your Puppet Master Console certificate has not been imported into your work station certificate store.
+
+If you want to use this cmdlet in an automated environment make sure you create the credential object in your script. If you do not pass a credential the cmdlet will hang the script waiting for you to enter credentials at the commandline.
 
 ```powershell
-$master = 'puppet.contoso.com'
-$cred = Get-Credential -Message 'Puppet Credentials (e.g. myuser-p)'
-$req = [PSCustomObject]@{
-    login       = $cred.UserName
-    password    = $cred.GetNetworkCredential().Password
-    lifetime    = '1d'
-    description = "Token used for testing puppet tasks"
-    client      = ""
-    label       = "personal workstation token"
-} | ConvertTo-Json
-$rbacUri = "https://$master`:4433/rbac-api/v1/auth/token"
-$result  = Invoke-RestMethod -Uri $rbacUri -Method Post -Body $req -ContentType 'application/json'
-$result
+$creds = Get-Credential
+
+$token = Get-PuppetAuthToken -Master '<Master FQDN>' -SkipCertificateCheck -Credential $creds
 ```
 
 OUTPUT
 
 ```plaintext
-token
------
 ***********************************wCB8
 ```
 

--- a/Tests/Get-PuppetAuthToken.Tests.ps1
+++ b/Tests/Get-PuppetAuthToken.Tests.ps1
@@ -1,0 +1,42 @@
+InModuleScope PSPuppetOrchestrator {
+    Describe 'Get-PuppetAuthToken' -Tag unit {
+        function Invoke-RestMethod {param([switch]$SkipCertificateCheck)}
+        $password = ConvertTo-SecureString "password" -AsPlainText -Force
+        $creds = New-Object System.Management.Automation.PSCredential -ArgumentList ('admin', $password)
+        Mock Invoke-RestMethod { [pscustomobject]@{token = "MockedTokenText" } }
+
+        context 'Invoke-RestMethod Supports Skip Certificate Check' {
+            Mock Get-Help { $true }
+            Mock Set-ServerCertificateValidationCallback {}
+
+            it "Should use -SkipCertificateCheck if Invoke-RestMethod supports it" {
+                Get-PuppetAuthToken -Master 'master' -Credential $creds -SkipCertificateCheck | Should -Be "MockedTokenText"
+                Assert-MockCalled -CommandName 'Invoke-RestMethod' -Times 1 -Exactly -Scope It -ParameterFilter { $true -eq $PSBoundParameters.ContainsKey('SkipCertificateCheck')}
+                Assert-MockCalled -CommandName 'Set-ServerCertificateValidationCallback' -Times 0 -Scope It
+            }
+
+            it "Should not use -SkipCertificateCheck if the invocation omits it" {
+                Get-PuppetAuthToken -Master 'master' -Credential $creds | Should -Be "MockedTokenText"
+                Assert-MockCalled -CommandName 'Invoke-RestMethod' -Times 1 -Exactly -Scope It -ParameterFilter { $false -eq $PSBoundParameters.containsKey('SkipCertificateCheck') }
+                Assert-MockCalled -CommandName 'Set-ServerCertificateValidationCallback' -Times 0 -Scope It
+            }
+        }
+
+        context 'Invoke-RestMethod does not support Skip Certificate Check' {
+            Mock Get-Help { $false }
+            Mock Set-ServerCertificateValidationCallback {}
+
+            it "Should set cert callback method it" {
+                Get-PuppetAuthToken -Master 'master' -Credential $creds -SkipCertificateCheck | Should -Be "MockedTokenText"
+                Assert-MockCalled -CommandName 'Invoke-RestMethod' -Times 1 -Exactly -Scope It -ParameterFilter {$false -eq $PSBoundParameters.ContainsKey('SkipCertificateCheck')}
+                Assert-MockCalled -CommandName 'Set-ServerCertificateValidationCallback' -Scope It
+            }
+
+            it "Should not use set the callback method if the invocation omits it" {
+                Get-PuppetAuthToken -Master 'master' -Credential $creds | Should -Be "MockedTokenText"
+                Assert-MockCalled -CommandName 'Invoke-RestMethod' -Times 1 -Exactly -Scope It -ParameterFilter {$false -eq $PSBoundParameters.ContainsKey('SkipCertificateCheck')}
+                Assert-MockCalled -CommandName 'Set-ServerCertificateValidationCallback' -Times 0 -Scope It
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the Get-PuppetAuthToken cmdlet.

It also adds some private functions that help with checking to see if
the -SkipCertificateCheck flag is supported in the Invoke-RestMethod
cmdlet in the current session, and if not, setting the
ServerCertificateValidationCallback setting, so that PS 5.1 can
connect to Puppet Masters that have an untrusted SSL cert.

The Set-ServerCertificateValidationCallback cmdlet is there purely as
a stub for mocking to make it easier to pester test that code path.
