### PR TITLE
Use PowerShellBuild 0.4.0 for all psake tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Don't check in the Output dir
 BuildOutput/
+Output/
 .DS_Store
 
 # OS generated files #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.1.9]
+### Added
+- Move to 100% PowerShellBuild `0.4.0` build process.
+
 ## [0.1.8]
-## Added
-- `Get-PuppetAuthToken` You can now provide a server name for your Puppet master and optionally a listening port, along with a credential, and easily obtain an api auth token for use with the rest of the cmdlets in the module.
+### Added
+- `Get-PuppetAuthToken` You can now provide a server name for your Puppet master and optionally a listening port, along with a credential, and easily obtain an api auth token for use with the rest of the cmdlets in the module. (via [RandomNoun7](https://github.com/RandomNoun7))
 
 ## [0.1.7]
 ### Changed

--- a/PSPuppetOrchestrator/PSPuppetOrchestrator.psd1
+++ b/PSPuppetOrchestrator/PSPuppetOrchestrator.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSPuppetOrchestrator.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.8'
+ModuleVersion = '0.1.9'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Tests/Get-PuppetAuthToken.Tests.ps1
+++ b/Tests/Get-PuppetAuthToken.Tests.ps1
@@ -1,3 +1,7 @@
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
+
 InModuleScope PSPuppetOrchestrator {
     Describe 'Get-PuppetAuthToken' -Tag unit {
         function Invoke-RestMethod {param([switch]$SkipCertificateCheck)}

--- a/Tests/Get-PuppetJob.Tests.ps1
+++ b/Tests/Get-PuppetJob.Tests.ps1
@@ -1,3 +1,7 @@
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
+
 InModuleScope PSPuppetOrchestrator {
     Describe 'Get-PuppetJob' -Tag unit {
         function Invoke-RestMethod {}

--- a/Tests/Get-PuppetJobReport.Tests.ps1
+++ b/Tests/Get-PuppetJobReport.Tests.ps1
@@ -1,3 +1,7 @@
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
+
 InModuleScope PSPuppetOrchestrator {
     Describe 'Get-PuppetJobReport' -Tag unit {
         function Invoke-RestMethod {}

--- a/Tests/Get-PuppetJobResults.Tests.ps1
+++ b/Tests/Get-PuppetJobResults.Tests.ps1
@@ -1,3 +1,7 @@
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
+
 InModuleScope PSPuppetOrchestrator {
     Describe 'Get-PuppetJobResults' -Tag unit {
         function Invoke-RestMethod {}

--- a/Tests/Get-PuppetNodePCPBrokerDetails.Tests.ps1
+++ b/Tests/Get-PuppetNodePCPBrokerDetails.Tests.ps1
@@ -1,3 +1,7 @@
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
+
 InModuleScope PSPuppetOrchestrator {
     Describe 'Get-PuppetPCPNodeBrokerDetails' -Tag unit {
         function Invoke-RestMethod {}

--- a/Tests/Get-PuppetTask.Tests.ps1
+++ b/Tests/Get-PuppetTask.Tests.ps1
@@ -1,3 +1,7 @@
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
+
 InModuleScope PSPuppetOrchestrator {
     Describe 'Get-PuppetTask' -Tag unit {
         function Invoke-RestMethod {}

--- a/Tests/Get-PuppetTasks.Tests.ps1
+++ b/Tests/Get-PuppetTasks.Tests.ps1
@@ -1,3 +1,7 @@
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
+
 InModuleScope PSPuppetOrchestrator {
     Describe 'Get-PuppetTasks' -Tag unit {
         function Invoke-RestMethod {}

--- a/Tests/Help.tests.ps1
+++ b/Tests/Help.tests.ps1
@@ -1,17 +1,10 @@
 
 # Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
 
-#$outputDir       = Join-Path -Path $ENV:BHProjectPath -ChildPath 'Output'
-$outputDir       = $ENV:BHBuildOutput
-$outputModDir    = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
-$manifest        = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
-$outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+Get-Module $env:BHProjectName | Remove-Module -Force
+$ModuleManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+Import-Module $ModuleManifestPath -Force
 
-# Get module commands
-# Remove all versions of the module from the session. Pester can't handle multiple versions.
-#Get-Module $env:BHProjectName | Remove-Module -Force
-#Import-Module -Name (Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1") -Verbose:$false -ErrorAction Stop
-Import-Module $outputModDir
 $commands = Get-Command -Module (Get-Module $env:BHProjectName) -CommandType Cmdlet, Function  # Not alias
 
 ## When testing help, remember that help is cached at the beginning of each session.

--- a/Tests/Manifest.tests.ps1
+++ b/Tests/Manifest.tests.ps1
@@ -1,10 +1,7 @@
 
 $moduleName         = $env:BHProjectName
-$manifest           = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
-$outputDir          = Join-Path -Path $ENV:BHProjectPath -ChildPath 'BuildOutput'
-$outputModDir       = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
-$outputModVerDir    = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
-$outputManifestPath = Join-Path -Path $outputModDir -Child "$($moduleName).psd1"
+$outputManifestPath = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
+$manifest           = Import-PowerShellDataFile -Path $outputManifestPath
 $changelogPath      = Join-Path -Path $env:BHProjectPath -Child 'CHANGELOG.md'
 
 Describe 'Module manifest' {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.1.6.{build}
+version: 0.1.9.{build}
 
 environment:
   matrix:
@@ -8,7 +8,7 @@ environment:
       PowerShellEdition: WindowsPowerShell
 
 skip_commits:
-  message: /updated readme.*|update readme.*|update changelog.*|update changelog.*s/
+  message: /doc update.*|updated readme.*|update readme.*|update changelog.*|update changelog.*s/
 build: off
 
 # Kick off the CI/CD pipeline

--- a/docs/en-US/Set-ServerCertificateValidationCallback.md
+++ b/docs/en-US/Set-ServerCertificateValidationCallback.md
@@ -13,7 +13,7 @@ A stub for testing purposes.
 ## SYNTAX
 
 ```
-Set-ServerCertificateValidationCallback
+Set-ServerCertificateValidationCallback [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,6 +33,9 @@ the ServerCertificateValidationCallback method in a way that's easier to
 Mock during testing.
 
 ## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -1,158 +1,16 @@
 properties {
-    $projectRoot = $ENV:BHProjectPath
-    if(-not $projectRoot) {
-        $projectRoot = $PSScriptRoot
-    }
-    $modulePath = $env:BHModulePath
-    $tests = "$projectRoot\Tests"
-    $outputDir = $ENV:BHBuildOutput
-    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
-    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
-    $psVersion = $PSVersionTable.PSVersion.Major
-    $projectLocale = 'en-US'
+    # vars to support psake task UploadTestResults used in appveyor.yml
+    $testResultsPath = Join-Path -Path $PSScriptRoot -ChildPath "output/$env:BHProjectName/testResults.xml"
+    $PSBPreference.Test.OutputFile = $testResultsPath
+    # other PowerShellBuild preferences
+    $PSBPreference.Build.CompileModule = $true
 }
 
-<#
-    hi there, if you're looking to contriubute please understand this psakeFile is a work in progress.
-    pretty sloppy and a bit of a mess at the moment.
-#>
-
 task default -depends Test
-task RegenerateHelp -Depends UpdateMarkdownHelp, CreateExternalHelp -description 'Regenerate help'
-task Test -Depends Init, Analyze, Pester -description 'Run test suite'
 
-task Init {
-    "`nSTATUS: Testing with PowerShell $psVersion"
-    "Build System Details:"
-    Get-Item ENV:BH*
-    "`n"
-} -description 'Initialize build environment'
-
-task Analyze -Depends Build {
-    $analysis = Invoke-ScriptAnalyzer -Path $outputModDir -Verbose:$false
-    $errors = $analysis | Where-Object {$_.Severity -eq 'Error'}
-    $warnings = $analysis | Where-Object {$_.Severity -eq 'Warning'}
-
-    if (($errors.Count -eq 0) -and ($warnings.Count -eq 0)) {
-        '    PSScriptAnalyzer passed without errors or warnings'
-    }
-
-    if (@($errors).Count -gt 0) {
-        Write-Error -Message 'One or more Script Analyzer errors were found. Build cannot continue!'
-        $errors | Format-Table
-    }
-
-    if (@($warnings).Count -gt 0) {
-        Write-Warning -Message 'One or more Script Analyzer warnings were found. These should be corrected.'
-        $warnings | Format-Table
-    }
-} -description 'Run PSScriptAnalyzer'
-
-task Pester -Depends Build {
-    Push-Location
-    Set-Location -PassThru $outputModDir
-    if (-not $ENV:BHProjectPath) {
-        Set-BuildEnvironment -Path $PSScriptRoot\..
-    }
-
-    $origModulePath = $env:PSModulePath
-    if ( $env:PSModulePath.split($pathSeperator) -notcontains $outputDir ) {
-        $env:PSModulePath = ($outputDir + $pathSeperator + $origModulePath)
-    }
-
-    Remove-Module $ENV:BHProjectName -ErrorAction SilentlyContinue -Verbose:$false
-    Import-Module -Name $outputModDir -Force -Verbose:$false
-    $testResultsXml = Join-Path -Path $outputDir -ChildPath 'testResults.xml'
-    $testResults = Invoke-Pester -Path $tests -PassThru -OutputFile $testResultsXml -OutputFormat NUnitXml
-
-    if ($testResults.FailedCount -gt 0) {
-        $testResults | Format-List
-        Write-Error -Message 'One or more Pester tests failed. Build cannot continue!'
-    }
-    Pop-Location
-    $env:PSModulePath = $origModulePath
-} -description 'Run Pester tests'
-
-task Build -depends Compile, CreateMarkdownHelp, CreateExternalHelp {
-    $OutputModDirDataFile = Join-Path -Path $OutputModDir -ChildPath "$($ENV:BHProjectName).psd1"
-    # Bump the module version if we didn't already
-    Try
-    {
-        $GalleryVersion = Get-NextNugetPackageVersion -Name $env:BHProjectName -ErrorAction Stop
-        $GithubVersion = Get-MetaData -Path $env:BHPSModuleManifest -PropertyName ModuleVersion -ErrorAction Stop
-        if($GalleryVersion -ge $GithubVersion) {
-            Update-Metadata -Path $env:BHPSModuleManifest -PropertyName ModuleVersion -Value $GalleryVersion -ErrorAction stop
-        }
-    }
-    Catch
-    {
-        "Failed to update version for '$env:BHProjectName': $_.`nContinuing with existing version"
-    }
-    Push-Location -Path $OutputDir
-    Write-Verbose -Message 'Adding exported functions to psd1...'
-    Set-ModuleFunction
-    Pop-Location
-    "    Exported public functions added to output data file at [$OutputModDirDataFile]"
-} -description 'Adds exported functions to psd1'
-
-task Compile -depends Clean {
-    # Create module output directory
-    New-Item -Path $OutputModDir -ItemType Directory > $null
-
-    # Append items to psm1
-    Write-Verbose -Message 'Creating psm1...'
-    $psm1 = Copy-Item -Path (Join-Path -Path $ModulePath -ChildPath "$($ENV:BHProjectName).psm1") -Destination (Join-Path -Path $OutputModDir -ChildPath "$($ENV:BHProjectName).psm1") -PassThru
-
-    # Add public and private functions to psms1-
-    Get-ChildItem -Path (Join-Path -Path $ModulePath -ChildPath 'Private') -Recurse |
-        Get-Content -Raw | Add-Content -Path $psm1 -Encoding UTF8
-    Get-ChildItem -Path (Join-Path -Path $ModulePath -ChildPath 'Public') -Recurse |
-        Get-Content -Raw | Add-Content -Path $psm1 -Encoding UTF8
-    Copy-Item -Path $env:BHPSModuleManifest -Destination $OutputModDir
-    "    Created compiled module at [$OutputModDir]"
-} -description 'Compiles module from source'
-
-task Clean -depends Init {
-    Remove-Module -Name $env:BHProjectName -Force -ErrorAction SilentlyContinue
-
-    if (Test-Path -Path $outputDir) {
-        Get-ChildItem -Path $outputDir -Recurse | Remove-Item -Force -Recurse
-    } else {
-        New-Item -Path $outputDir -ItemType Directory > $null
-    }
-    "    Cleaned previous output directory [$outputDir]"
-} -description 'Cleans module output directory'
-
-task CreateMarkdownHelp -Depends Compile {
-    # functions
-    Import-Module -Name $outputModDir -Verbose:$false -Global
-    $mdHelpPath = Join-Path -Path $projectRoot -ChildPath "docs/$projectLocale"
-    $mdFiles = New-MarkdownHelp -Module $env:BHProjectName -OutputFolder $mdHelpPath -WithModulePage -Force
-    "    $env:BHProjectName markdown help created at [$mdHelpPath]"
-
-    @($env:BHProjectName).ForEach({
-        Remove-Module -Name $_ -Verbose:$false
-    })
-} -description 'Create initial markdown help files'
-
-task UpdateMarkdownHelp -Depends Compile {
-    Import-Module -Name $outputModDir -Verbose:$false -Global
-    $mdHelpPath = Join-Path -Path $projectRoot -ChildPath "docs\$projectLocale"
-    $mdFiles = Update-MarkdownHelpModule -Path $mdHelpPath -Verbose:$false
-    "    Markdown help updated at [$mdHelpPath]"
-} -description 'Update markdown help files'
-
-task CreateExternalHelp -Depends CreateMarkdownHelp {
-    New-ExternalHelp "$projectRoot\docs\$projectLocale" -OutputPath "$OutputModDir" -Force > $null
-} -description 'Create module help from markdown files'
-
-task Publish -Depends Test {
-    "    Publishing version [$($manifest.ModuleVersion)] to PSGallery..."
-    Publish-Module -Path $OutputModDir -NuGetApiKey $env:PSGALLERY_API_KEY -Repository PSGallery
-} -description 'Publish module'
+task Test -FromModule PowerShellBuild -Version '0.4.0'
 
 task UploadTestResults {
-    # upload results to AppVeyor
     $wc = New-Object 'System.Net.WebClient'
-    $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Join-Path -Path $OutputDir -ChildPath 'testResults.xml'))
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", $testResultsPath)
 } -description 'Uploading tests'


### PR DESCRIPTION
Use PowerShellBuild 0.4.0 for all psake tasks.

## Description
Use PowerShellBuild 0.4.0 for all psake tasks.
- This required a minor refactor of all PSPuppetOrchestrator `tests.ps1` files so that the project module is imported prior to the tests being run. This will hopefully be addressed in PowerShellBuild `0.5.0`. 
- Small refactor to `Manifest.tests.ps1 ` and `help.tests.ps1` to load needed project module files from new output directory. 
- Add ad-hoc psake task `UploadTestResults` that is triggered via `appveyor.yml`. 

## Related Issue
#10. Using PowerShellBuild 0.4.0 build process the `.psd1` is built correctly so that only public functions are exported. 

## Motivation and Context
1. previous psake tasks were a mess.
2. fixing #10 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
Use PowerShellBuild 0.4.0 for all psake tasks.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixes #10 